### PR TITLE
Fixed channel date stat bug

### DIFF
--- a/src/clojurians_log/db/queries.clj
+++ b/src/clojurians_log/db/queries.clj
@@ -165,8 +165,11 @@
        to-day))
 
 (defn channel-message-stats-between-days [from-day to-day channel-name]
-  (letfn [(chan-day-cnt [] (:chan-day-cnt @!indexes))]
-    (mapv #(hash-map :day (first %) :msg-count (last %)) (get (chan-day-cnt) (get-channel-id-by-name channel-name)))))
+  (let [chan-day-cnt (:chan-day-cnt @!indexes)
+        chan-day-data (get chan-day-cnt (get-channel-id-by-name channel-name) {})
+        range-of-days (time-util/range-of-days from-day to-day)]
+        (println chan-day-data)
+    (mapv #(hash-map :day % :msg-count (get chan-day-data % 0)) range-of-days)))
     
 (defn message-stats-between-days [from-day to-day]
   (letfn [(day-chan-cnt [] (:day-chan-cnt @!indexes))


### PR DESCRIPTION
Earlier it was not honoring the date range data with channel name

<!--
This process uses the Collective Code Construction Contract
https://rfc.zeromq.org/spec:44/C4/

We merge quickly, but do keep a few things in mind

- make small PRs
- state the problem you are addressing (Problem: ... Solution: ...)
- add yourself to CONTRIBUTORS.md
- try not to break the build
-->
